### PR TITLE
Remove preceding slash to fix img bug

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -124,10 +124,10 @@ async function startGeneratingImage() {
 	imgs = [];
 
 	imageURLs = [];
-	imageURLs.push(avatarImageSrc ? avatarImageSrc : '/img/bird.png');
+	imageURLs.push(avatarImageSrc ? avatarImageSrc : 'img/bird.png');
 
-	imageURLs.push('/img/' + background);
-	imageURLs.push('/img/bird.png');
+	imageURLs.push('img/' + background);
+	imageURLs.push('img/bird.png');
 
 	statePath = '';
 	if (endorseeInfo.state !== undefined && endorseeInfo.state !== '') {


### PR DESCRIPTION
Summary
---------
This pull request fixes a critical pug that prevented endorsements from being generated.

| BEFORE|AFTER|
|---|---|
|![image](https://user-images.githubusercontent.com/38898288/82738080-35206680-9d03-11ea-9d96-bdad159e8b51.png)|![image](https://user-images.githubusercontent.com/38898288/82738016-d4912980-9d02-11ea-8111-fabd59da4848.png)|

Technical Details
--------
A slash "/" preceded image paths resulted in image files being read as undefined. 

By removing the slash, images are appropriately requested from the `img` directly and now endorsements can be generated.